### PR TITLE
feat: port terraform validation workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    reviewers:
+      - jamieastley
+    assignees:
+      - jamieastley
+    schedule:
+      interval: "daily"
+      time: "12:00"
+      timezone: "Australia/Sydney"

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,18 @@
+name: Create GitHub release
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+*
+
+jobs:
+  create_gh_release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        if: steps.validate.outputs.exit_code == 0
+        with:
+          generate_release_notes: true

--- a/.github/workflows/validate_terraform_module.yml
+++ b/.github/workflows/validate_terraform_module.yml
@@ -1,0 +1,64 @@
+on:
+  workflow_call:
+    inputs:
+      terraform_version:
+        description: 'Terraform version to use'
+        required: true
+        default: 'latest'
+        type: string
+      working-directory:
+        description: 'Working directory to run Terraform commands in'
+        required: false
+        default: '.'
+        type: string
+      runs-on:
+        description: 'The type of machine to run the job on'
+        required: false
+        default: 'ubuntu-latest'
+        type: string
+
+    outputs:
+      fmtOutcome:
+        description: 'Outcome of terraform fmt -check'
+        value: ${{ jobs.validate.outputs.fmtOutcome }}
+      initOutcome:
+        description: 'Outcome of terraform init'
+        value: ${{ jobs.validate.outputs.initOutcome }}
+      validateOutcome:
+        description: 'Outcome of terraform validate'
+        value: ${{ jobs.validate.outputs.validateOutcome }}
+      validateOutput:
+        description: 'stdout of terraform validate'
+        value: ${{ jobs.validate.outputs.validateOutput }}
+
+jobs:
+  validate:
+    runs-on: ${{ inputs.runs-on }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    outputs:
+      fmtOutcome: ${{ steps.fmt.outcome }}
+      initOutcome: ${{ steps.init.outcome }}
+      validateOutcome: ${{ steps.validate.outcome}}
+      validateOutput: ${{ steps.validate.outputs.stdout}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ vars.TERRAFORM_VERSION }}
+
+      - name: Terraform Format
+        id: fmt
+        run: terraform fmt -check
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# JetBrains
+.idea/
+
+# MacOS
+.DS_Store


### PR DESCRIPTION
Ports the terraform validation workflow used in other projects to this repository for a single source of truth.

- added dependabot.yml
- added release workflow to create GitHub release when tags are pushed